### PR TITLE
end_timeのvalidates（start_timeより前日付にならない）を追加

### DIFF
--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -15,7 +15,7 @@ class SchedulesController < ApplicationController
       ScheduleMailer.creation_schedule_email(@schedule).deliver_now
       redirect_to root_path, notice: "新規スケジュールを登録しました。"
     else
-      render :new, notice: "スケジュールの作成に失敗しました。"
+      render :new, notice: "スケジュールの作成に失敗しました。", status: :unprocessable_entity
     end
   end
 
@@ -30,7 +30,7 @@ class SchedulesController < ApplicationController
       ScheduleMailer.creation_schedule_email(@schedule).deliver_now
       redirect_to root_path, notice: "新規スケジュールを更新しました。"
     else
-      render :edit, notice: "スケジュールの更新に失敗しました。"
+      render :edit, notice: "スケジュールの更新に失敗しました。", status: :unprocessable_entity
     end
   end
 

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -22,4 +22,12 @@ class Schedule < ApplicationRecord
   validates :title, presence: true
   validates :start_time, presence: true
   validates :end_time, presence: true
+
+  validate :end_time_is_not_before_start_time
+
+  def end_time_is_not_before_start_time
+    if self.start_time > self.end_time
+      errors.add(:end_time, "は開始日より前の日付で登録できません。")
+    end
+  end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,8 +8,9 @@ ja:
           has_many: "%{record}が存在しているので削除できません"
     attributes:
       schedule:
-        previous: '前月'
-        next: '翌月'
+        title: 'タイトル'
+        start_time: '開始日'
+        end_time: '終了日'
   date:
     abbr_day_names:
     - 日


### PR DESCRIPTION
scheduleモデルに”end_time_is_not_before_start_time”メソッドを定義し、そこでvalidatesを実装。
エラーメッセージを表示するためにコントローラに"status: :unprocessable_entity"を追記